### PR TITLE
Fix DirtyJson array parsing

### DIFF
--- a/python/helpers/dirty_json.py
+++ b/python/helpers/dirty_json.py
@@ -261,4 +261,16 @@ class DirtyJson:
         return result
 
     def index_of_first_brace(self, input_str: str) -> int:
-        return input_str.find("{")
+        """Return the index of the first opening JSON character.
+
+        The original implementation only searched for ``{`` which caused
+        ``parse`` to fail when the JSON string started with an array.  We now
+        search for both ``{`` and ``[`` and return the earliest occurrence.
+        If neither is found ``0`` is returned so parsing starts from the
+        beginning of the string.
+        """
+
+        brace_positions = [pos for pos in [input_str.find("{"), input_str.find("[")] if pos != -1]
+        if not brace_positions:
+            return 0
+        return min(brace_positions)

--- a/tests/helpers/test_json_parse_dirty.py
+++ b/tests/helpers/test_json_parse_dirty.py
@@ -55,6 +55,11 @@ class TestJsonParseDirty(unittest.TestCase):
         }
         self.assertEqual(json_parse_dirty(json_string), expected_result)
 
+    def test_array_json(self):
+        json_string = '[1, 2, 3]'
+        expected_output = [1, 2, 3]
+        self.assertEqual(DirtyJson.parse_string(json_string), expected_output)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `DirtyJson.index_of_first_brace` to handle JSON arrays
- add regression test covering array parsing

## Testing
- `python - <<'PY'
import sys, types, re
regex = types.SimpleNamespace(search=re.search)
sys.modules['regex'] = regex
import tests.helpers.test_json_parse_dirty as t
import unittest
res = unittest.TextTestRunner(verbosity=1).run(unittest.defaultTestLoader.loadTestsFromModule(t))
print('passed:', res.wasSuccessful())
PY`