### PR TITLE
Fix merge_bulks_by condition

### DIFF
--- a/python/helpers/history.py
+++ b/python/helpers/history.py
@@ -413,7 +413,7 @@ class History(Record):
         return compressed
 
     async def merge_bulks_by(self, count: int):
-        if len(self.bulks) > 0:
+        if len(self.bulks) < count:
             return False
         bulks = await asyncio.gather(
             *[


### PR DESCRIPTION
## Summary
- fix merging condition to only merge when at least BULK_MERGE_COUNT bulks exist

## Testing
- `python -m py_compile python/helpers/history.py`
