### PR TITLE
Fix successful spelling in prompts

### DIFF
--- a/prompts/default/fw.memory.hist_suc.sys.md
+++ b/prompts/default/fw.memory.hist_suc.sys.md
@@ -1,7 +1,7 @@
 # Assistant's job
 1. The assistant receives a history of conversation between USER and AGENT
-2. Assistant searches for succesful technical solutions by the AGENT
-3. Assistant writes notes about the succesful solution for later reproduction
+2. Assistant searches for successful technical solutions by the AGENT
+3. Assistant writes notes about the successful solution for later reproduction
 
 # Format
 - The response format is a JSON array of successful solutions containing "problem" and "solution" properties

--- a/prompts/default/memory.solutions_sum.sys.md
+++ b/prompts/default/memory.solutions_sum.sys.md
@@ -1,10 +1,10 @@
 # Assistant's job
 1. The assistant receives a history of conversation between USER and AGENT
-2. Assistant searches for succesful technical solutions by the AGENT
-3. Assistant writes notes about the succesful solution for later reproduction
+2. Assistant searches for successful technical solutions by the AGENT
+3. Assistant writes notes about the successful solution for later reproduction
 
 # Format
-- The response format is a JSON array of succesfull solutions containng "problem" and "solution" properties
+- The response format is a JSON array of successful solutions containng "problem" and "solution" properties
 - The problem section contains a description of the problem, the solution section contains step by step instructions to solve the problem including necessary details and code.
 - If the history does not contain any helpful technical solutions, the response will be an empty JSON array.
 


### PR DESCRIPTION
## Summary
- fix spelling of "successful" in prompts

## Testing
- `grep -n "succes" prompts/default/memory.solutions_sum.sys.md`
- `grep -n "succes" prompts/default/fw.memory.hist_suc.sys.md`
